### PR TITLE
Allow find in blobs.sh to follow links

### DIFF
--- a/blobs.sh
+++ b/blobs.sh
@@ -71,7 +71,7 @@ case "$OS" in
   darwin)  LIB_NAME="libraylib.dylib" ;;
 esac
 
-FOUND="$(find "$TMP" -type f -name "$LIB_NAME*" | head -n 1)"
+FOUND="$(find -L "$TMP" -type f -name "$LIB_NAME*" | head -n 1)"
 
 if [ -z "$FOUND" ]; then
   echo "Library not found"


### PR DESCRIPTION
Currently, `$FOUND` is empty when `libraylib.dylib` is a symbolic link.
I believe this will fix it.